### PR TITLE
chore: rebrand aiBuddy to WorkflowWonder

### DIFF
--- a/IMPLEMENTATION_PLANS/REBRAND_IMPL_PLAN.md
+++ b/IMPLEMENTATION_PLANS/REBRAND_IMPL_PLAN.md
@@ -1,0 +1,39 @@
+# WorkflowWonder Rebrand Implementation Plan
+
+**Status:** Approved for implementation  
+**Current brand:** aiBuddy  
+**Target brand:** WorkflowWonder  
+**Selected direction:** Option 3 primary (wordmark + workflow path icon), Option 1 compact fallback (`WFW`)
+
+## Goal
+
+Migrate brand identity from `aiBuddy` to `WorkflowWonder` across user-facing surfaces with a professional, simple, trust-inspiring presentation.
+
+## Scope
+
+- Update visible brand text, headline brand references, and metadata naming.
+- Apply Option 3 as primary visual mark.
+- Keep Option 1 compact mark as fallback for small contexts.
+- Validate brand quality on mobile layouts.
+
+## Execution Phases
+
+1. Brand lock (Option 3 primary, Option 1 fallback).
+2. Asset/component integration for primary and compact marks.
+3. Copy and metadata replacement pass.
+4. Mobile-first brand QA and final sweep.
+
+## Acceptance Checklist
+
+- [ ] WorkflowWonder appears in user-facing brand surfaces.
+- [ ] Option 3 is used as the primary brand mark.
+- [ ] Option 1 compact fallback is present for small surfaces.
+- [ ] Mobile brand validation passes at `360px`, `390px`, and `412px`.
+- [ ] No unintended `aiBuddy` references remain in target surfaces.
+
+## Mobile Brand Validation
+
+- Confirm brand mark/wordmark readability at small sizes (`16px`, `24px`, `32px` contexts).
+- Check header branding at `360px`, `390px`, and `412px` widths.
+- Confirm spacing near primary CTAs remains clear and uncluttered.
+- Verify contrast and readability in common mobile viewing conditions.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# aiBuddy
+# WorkflowWonder
 
-Landing and marketing site for **aiBuddy** — web design and automation services.
+Landing and marketing site for **WorkflowWonder** — web design and automation services.
 
 ## Repo
 
@@ -12,6 +12,7 @@ Landing and marketing site for **aiBuddy** — web design and automation service
 - [Frontend implementation plan](./IMPLEMENTATION_PLANS/FRONTEND_IMPLEMENTATION_PLAN.md)
 - [Repo & Vercel setup](./IMPLEMENTATION_PLANS/REPO_AND_VERCEL_SETUP_PLAN.md)
 - [Custom domain (wfwonder.com)](./IMPLEMENTATION_PLANS/CUSTOM_DOMAIN_IMPL_PLAN.md)
+- [Rebrand implementation plan](./IMPLEMENTATION_PLANS/REBRAND_IMPL_PLAN.md)
 
 ## App
 

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -21,22 +21,22 @@ export const metadata: Metadata = {
     process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000",
   ),
   title: {
-    default: "aiBuddy — Web design & automation",
-    template: "%s · aiBuddy",
+    default: "WorkflowWonder — Web design & automation",
+    template: "%s · WorkflowWonder",
   },
   description:
     "Premium web design and workflow automation. Schedule an audit or get in touch.",
   openGraph: {
-    title: "aiBuddy — Web design & automation",
+    title: "WorkflowWonder — Web design & automation",
     description:
       "Premium web design and workflow automation for teams that outgrow brittle tools.",
     locale: "en",
     type: "website",
-    siteName: "aiBuddy",
+    siteName: "WorkflowWonder",
   },
   twitter: {
     card: "summary_large_image",
-    title: "aiBuddy — Web design & automation",
+    title: "WorkflowWonder — Web design & automation",
     description:
       "Premium web design and workflow automation for teams that outgrow brittle tools.",
   },

--- a/web/src/components/brand/BrandMark.tsx
+++ b/web/src/components/brand/BrandMark.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+type BrandMarkProps = {
+  compact?: boolean;
+  className?: string;
+};
+
+export function BrandMark({ compact = false, className }: BrandMarkProps) {
+  if (compact) {
+    return (
+      <span
+        aria-label="WorkflowWonder compact mark"
+        className={`inline-flex items-center rounded-md border border-[var(--border-strong)] bg-[var(--surface)] px-2 py-1 text-xs font-semibold tracking-[0.14em] text-[var(--foreground)] ${className ?? ""}`}
+      >
+        WW
+      </span>
+    );
+  }
+
+  return (
+    <span
+      aria-label="WorkflowWonder"
+      className={`inline-flex items-center gap-2 text-[var(--foreground)] ${className ?? ""}`}
+    >
+      <svg
+        viewBox="0 0 48 20"
+        aria-hidden
+        className="h-5 w-12 shrink-0 text-[var(--foreground)]"
+        fill="none"
+      >
+        <path
+          d="M2 3L8 17L13 8L18 17L24 3"
+          stroke="currentColor"
+          strokeWidth="2.2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M24 3L30 17L35 8L40 17L46 3"
+          stroke="currentColor"
+          strokeWidth="2.2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      <span className="font-display text-lg font-semibold tracking-tight">WorkflowWonder</span>
+    </span>
+  );
+}

--- a/web/src/components/sections/Footer.tsx
+++ b/web/src/components/sections/Footer.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { homeContent } from "@/content/home";
 import { getContactHref, getScheduleAuditUrl } from "@/lib/public-urls";
+import { BrandMark } from "@/components/brand/BrandMark";
 import { Container } from "@/components/ui/Container";
 import { SmartLink } from "@/components/ui/SmartLink";
 
@@ -17,9 +18,7 @@ export function Footer() {
       <Container>
         <div className="flex flex-col gap-10 md:flex-row md:justify-between">
           <div>
-            <p className="font-display text-xl font-semibold text-[var(--foreground)]">
-              {homeContent.brand}
-            </p>
+            <BrandMark className="align-middle" />
             <p className="mt-2 max-w-sm text-sm text-[var(--muted)]">
               {homeContent.tagline}
             </p>

--- a/web/src/components/sections/Header.tsx
+++ b/web/src/components/sections/Header.tsx
@@ -2,9 +2,9 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { homeContent } from "@/content/home";
 import { getContactHref, getScheduleAuditUrl } from "@/lib/public-urls";
 import { ButtonLink } from "@/components/ui/ButtonLink";
+import { BrandMark } from "@/components/brand/BrandMark";
 import { Container } from "@/components/ui/Container";
 
 const nav = [
@@ -24,9 +24,14 @@ export function Header() {
       <Container className="flex h-16 items-center justify-between gap-6">
         <Link
           href="#top"
-          className="font-display text-lg font-semibold tracking-tight text-[var(--foreground)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
+          className="focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]"
         >
-          {homeContent.brand}
+          <span className="hidden sm:inline-flex">
+            <BrandMark />
+          </span>
+          <span className="inline-flex sm:hidden">
+            <BrandMark compact />
+          </span>
         </Link>
 
         <nav

--- a/web/src/content/home.ts
+++ b/web/src/content/home.ts
@@ -1,5 +1,5 @@
 export const homeContent = {
-  brand: "aiBuddy",
+  brand: "WorkflowWonder",
   tagline: "Web design & automation for teams that outgrow brittle tools.",
   hero: {
     headline: "Design that converts. Automation that lasts.",
@@ -50,7 +50,7 @@ export const homeContent = {
     ],
   },
   differentiators: {
-    title: "Why aiBuddy",
+    title: "Why WorkflowWonder",
     points: [
       {
         title: "Premium execution",


### PR DESCRIPTION
## Summary
- Rebrand user-facing site and metadata from aiBuddy to WorkflowWonder.
- Add a reusable linked WW brand mark component with compact WW fallback for mobile/small contexts.
- Add and reference `IMPLEMENTATION_PLANS/REBRAND_IMPL_PLAN.md` for rebrand execution and mobile checks.

## Test plan
- [x] Run `npm run lint` in `web/`
- [x] Run `npm run build` in `web/`
- [x] Verify no `aiBuddy` strings remain in `web/`
- [x] Confirm temporary footer variant previews were removed and brand is consistent
