### PR TITLE
feat(services): add exclusive-toggle services page

### DIFF
--- a/IMPLEMENTATION_PLANS/SERVICES_PAGE_IMPL_PLAN.md
+++ b/IMPLEMENTATION_PLANS/SERVICES_PAGE_IMPL_PLAN.md
@@ -1,0 +1,142 @@
+# Services Page Implementation Plan (`/services`)
+
+**Status:** Planned  
+**Tracking issue:** [#9](https://github.com/aibudoptimization/aiBuddy/issues/9)  
+**Branch:** `feat/9-services-page-toggle`  
+**Milestone:** `Milestone B - Rebrand`
+
+---
+
+## 1) Goal
+
+Build a new `/services` page for wfwonder.com that matches existing site brand standards and delivers an **exclusive service toggle** UX:
+
+- exactly two services are available,
+- exactly one service panel is visible at any time,
+- switching is JavaScript-driven on a single route,
+- inactive content is fully removed from layout flow.
+
+---
+
+## 2) Requirements Mapping
+
+### Core UX behavior
+
+- Two service options only:
+  - `Web Design & Development`
+  - `Automated Workflows`
+- Toggle/tab control appears prominently near top of content area.
+- Active panel: visible (`display: block` or equivalent).
+- Inactive panel: hidden (`display: none` or equivalent), no remnant layout space.
+- No side-by-side presentation and no scroll-based service switching.
+
+### Brand consistency
+
+- Reuse/replicate existing site header and footer.
+- Ensure header nav contains `Services` linking to `/services`.
+- Match established color palette, typography, spacing, and component style.
+- Active toggle/tab state uses primary accent color token from existing design system.
+
+### Accessibility + motion
+
+- Toggle buttons expose `aria-selected`.
+- Panels use `role="tabpanel"` with valid `aria-labelledby` mappings.
+- Add subtle panel entrance animation (fade/slide) aligned with current site motion style.
+- Respect reduced-motion preferences if existing global styles include reduced-motion handling.
+
+### Content placeholders
+
+- Service body copy: `[Lorem ipsum placeholder text]`.
+- Service imagery: neutral placeholder block labeled `Service image placeholder`.
+
+---
+
+## 3) Proposed File Touchpoints
+
+Expected primary changes:
+
+- `web/src/app/services/page.tsx` (new page route)
+- Header/nav component(s) already used by current pages (ensure `Services` link exists and targets `/services`)
+- Shared style tokens/utilities if needed for tab active state and subtle transitions
+
+Optional supporting changes:
+
+- Reusable service toggle/panel component file if page logic grows
+- Minor footer/header refactor if needed to keep consistency without duplication
+
+---
+
+## 4) Implementation Steps
+
+1. **Discovery and reuse**
+   - Identify current header/footer source components used on existing pages.
+   - Confirm nav link structure and add/update `Services -> /services` if missing.
+
+2. **Route scaffolding**
+   - Create `web/src/app/services/page.tsx`.
+   - Compose page with shared header and footer wrappers consistent with current app architecture.
+
+3. **Exclusive toggle UX**
+   - Add a client-side stateful tab/toggle control for exactly two services.
+   - Render one active panel and hide inactive panel with `display: none` (or equivalent).
+   - Ensure no hidden panel occupies layout space.
+
+4. **Service panel content placeholders**
+   - Service 1 heading: `Web Design & Development`
+   - Service 2 heading: `Automated Workflows`
+   - Body copy: `[Lorem ipsum placeholder text]`
+   - Image block placeholder text: `Service image placeholder`
+
+5. **Brand styling alignment**
+   - Apply existing typography, spacing, and card/button styles from site tokens/components.
+   - Style active toggle state using the site's primary accent color.
+
+6. **Animation**
+   - Add subtle active panel transition (fade/slide).
+   - Keep animation lightweight and aligned with existing motion language.
+
+7. **Accessibility**
+   - Add `aria-selected` to tab controls.
+   - Add `role="tabpanel"` and matching `aria-labelledby`.
+   - Verify keyboard interaction and focus visibility.
+
+8. **Responsive QA**
+   - Validate mobile and desktop layouts.
+   - Ensure no horizontal overflow or panel clipping issues.
+
+---
+
+## 5) Acceptance Checklist (Issue #9 alignment)
+
+- [ ] `/services` route is implemented and renders correctly.
+- [ ] Header/footer match existing site components/style.
+- [ ] Nav includes `Services` link to `/services`.
+- [ ] Exactly two services are present.
+- [ ] Only one service panel is visible at a time.
+- [ ] Inactive panel is fully removed from layout flow.
+- [ ] Switching is JS-driven without page reload/sub-route navigation.
+- [ ] Active toggle uses primary accent color.
+- [ ] Subtle entrance animation exists for active panel.
+- [ ] Required ARIA roles/attributes are correctly wired.
+- [ ] Body copy and imagery remain placeholders as requested.
+- [ ] Mobile + desktop responsiveness verified.
+
+---
+
+## 6) Risks and Mitigations
+
+- **Risk:** Header/nav is duplicated in multiple places and can drift.
+  - **Mitigation:** Reuse existing shared components where possible; avoid one-off header markup.
+- **Risk:** Hidden panel still affects layout through visibility-only styles.
+  - **Mitigation:** Use `display: none` (or equivalent unmounted rendering path), then verify layout in both states.
+- **Risk:** Animation conflicts with reduced-motion expectations.
+  - **Mitigation:** Keep transition minimal and rely on existing reduced-motion handling patterns.
+
+---
+
+## 7) Definition of Done
+
+- Issue `#9` acceptance criteria are all checked.
+- Implementation merged via PR referencing `Closes #9`.
+- Progress and completion comments posted in issue per `GITHUB_ISSUES_GUIDE.md`.
+- Milestone status remains accurate (`Milestone B - Rebrand`).

--- a/web/src/app/services/page.tsx
+++ b/web/src/app/services/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { Header } from "@/components/sections/Header";
+import { Footer } from "@/components/sections/Footer";
+import { ServicesPageContent } from "@/components/sections/ServicesPageContent";
+
+export const metadata: Metadata = {
+  title: "Services",
+  description: "Explore WorkflowWonder services for web design, development, and automation.",
+};
+
+export default function ServicesPage() {
+  return (
+    <>
+      <Header />
+      <ServicesPageContent />
+      <Footer />
+    </>
+  );
+}

--- a/web/src/components/sections/Header.tsx
+++ b/web/src/components/sections/Header.tsx
@@ -8,7 +8,7 @@ import { BrandMark } from "@/components/brand/BrandMark";
 import { Container } from "@/components/ui/Container";
 
 const nav = [
-  { label: "Services", href: "#services" },
+  { label: "Services", href: "/services" },
   { label: "Estimate", href: "#calculator" },
   { label: "Process", href: "#process" },
   { label: "FAQ", href: "#faq" },

--- a/web/src/components/sections/ServicesPageContent.tsx
+++ b/web/src/components/sections/ServicesPageContent.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Container } from "@/components/ui/Container";
+
+const services = [
+  {
+    id: "web-design-development",
+    label: "Web Design & Development",
+    heading: "Web Design & Development",
+  },
+  {
+    id: "automated-workflows",
+    label: "Automated Workflows",
+    heading: "Automated Workflows",
+  },
+] as const;
+
+type ServiceId = (typeof services)[number]["id"];
+
+function ServicePanel({ heading }: { heading: string }) {
+  return (
+    <article className="rounded-2xl border border-[var(--border)] bg-[var(--surface)] p-6 shadow-sm shadow-black/20 sm:p-8">
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)] lg:items-start">
+        <div>
+          <h2 className="text-3xl font-medium tracking-tight text-[var(--foreground)] sm:text-4xl">{heading}</h2>
+          <p className="mt-5 max-w-2xl text-base leading-relaxed text-[var(--muted)] sm:text-lg">
+            [Lorem ipsum placeholder text]
+          </p>
+          <p className="mt-4 max-w-2xl text-base leading-relaxed text-[var(--muted)] sm:text-lg">
+            [Lorem ipsum placeholder text]
+          </p>
+        </div>
+        <div className="rounded-xl border border-[var(--border-strong)] bg-[var(--surface-elevated)] p-8 text-center">
+          <div className="flex min-h-52 items-center justify-center rounded-lg border border-dashed border-[var(--border-strong)] bg-[var(--background)]/35 p-6 text-sm font-semibold uppercase tracking-wide text-[var(--muted)]">
+            Service image placeholder
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function ServicesPageContent() {
+  const [activeService, setActiveService] = useState<ServiceId>(services[0].id);
+
+  const activeItem = useMemo(
+    () => services.find((service) => service.id === activeService) ?? services[0],
+    [activeService],
+  );
+
+  return (
+    <main id="main-content" className="flex-1">
+      <section className="border-b border-[var(--border)] bg-[var(--background)] py-20 sm:py-24" aria-label="Services">
+        <Container>
+          <div className="mx-auto w-full max-w-4xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-[var(--accent)]">Services</p>
+            <h1 className="mt-4 text-4xl font-medium tracking-tight text-[var(--foreground)] sm:text-5xl">
+              Choose the service you need right now
+            </h1>
+            <p className="mt-5 max-w-2xl text-base leading-relaxed text-[var(--muted)] sm:text-lg">
+              Use the toggle to switch between service details. Only one service panel is visible at a time.
+            </p>
+
+            <div
+              role="tablist"
+              aria-label="Service selection"
+              className="mt-10 grid w-full grid-cols-1 gap-3 rounded-xl border border-[var(--border)] bg-[var(--surface)] p-2 sm:grid-cols-2"
+            >
+              {services.map((service) => {
+                const selected = service.id === activeService;
+                const tabId = `${service.id}-tab`;
+                const panelId = `${service.id}-panel`;
+
+                return (
+                  <button
+                    key={service.id}
+                    id={tabId}
+                    type="button"
+                    role="tab"
+                    aria-selected={selected}
+                    aria-controls={panelId}
+                    onClick={() => setActiveService(service.id)}
+                    className={[
+                      "min-h-12 rounded-lg px-4 py-3 text-sm font-semibold tracking-wide transition-[background-color,color,border-color,box-shadow] motion-safe:duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--ring)]",
+                      selected
+                        ? "border border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-foreground)] shadow-sm shadow-black/20"
+                        : "border border-transparent bg-transparent text-[var(--foreground)] hover:border-[var(--border-strong)] hover:bg-[var(--surface-elevated)]",
+                    ].join(" ")}
+                  >
+                    {service.label}
+                  </button>
+                );
+              })}
+            </div>
+
+            {services.map((service) => {
+              const selected = service.id === activeService;
+              const tabId = `${service.id}-tab`;
+              const panelId = `${service.id}-panel`;
+
+              return (
+                <div
+                  key={service.id}
+                  id={panelId}
+                  role="tabpanel"
+                  aria-labelledby={tabId}
+                  style={{ display: selected ? "block" : "none" }}
+                  className={selected ? "mt-8 animate-[hero-fade-up_420ms_cubic-bezier(0.22,1,0.36,1)_both]" : ""}
+                >
+                  <ServicePanel heading={service.heading} />
+                </div>
+              );
+            })}
+
+            <p className="mt-5 text-sm text-[var(--muted)]">Currently viewing: {activeItem.label}</p>
+          </div>
+        </Container>
+      </section>
+    </main>
+  );
+}

--- a/web/src/content/home.ts
+++ b/web/src/content/home.ts
@@ -127,7 +127,7 @@ export const homeContent = {
       "Book a short audit or send a note—we’ll reply with practical next steps, not a generic pitch deck.",
     aboutLabel: "About us",
     pages: [
-      { label: "Services", href: "#services" },
+      { label: "Services", href: "/services" },
       { label: "Estimate", href: "#calculator" },
       { label: "Process", href: "#process" },
       { label: "FAQ", href: "#faq" },


### PR DESCRIPTION
## Summary
- Add a new `/services` page using shared site header/footer and current WorkflowWonder brand styling.
- Implement an accessible, JavaScript-driven exclusive service toggle with exactly two service panels and full layout removal of inactive content.
- Update global `Services` nav links to route to `/services` and add a tracking implementation plan document.

## Test plan
- [x] Run `npm run lint` in `web`
- [x] Verify `/services` returns HTTP 200 on localhost
- [ ] Manual browser QA on desktop/mobile breakpoints for toggle behavior and responsive layout
- [ ] Keyboard accessibility check for tab selection and focus visibility

Closes #9
